### PR TITLE
Broken Credential Stuffing link.

### DIFF
--- a/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication.md
+++ b/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication.md
@@ -49,7 +49,7 @@ Confirmation of the user's identity, authentication, and session management are 
 
 ### Example Attack Scenarios
 
-**Scenario #1**: [Credential stuffing](/www-community/attacks/Credental_stuffing), the use of [lists of known passwords](https://github.com/danielmiessler/SecLists), is a common attack. If an application does not implement automated threat or credential stuffing protections, the application can be used as a password oracle to determine if the credentials are valid.
+**Scenario #1**: [Credential stuffing](/www-community/attacks/Credential_stuffing), the use of [lists of known passwords](https://github.com/danielmiessler/SecLists), is a common attack. If an application does not implement automated threat or credential stuffing protections, the application can be used as a password oracle to determine if the credentials are valid.
 
 **Scenario #2**: Most authentication attacks occur due to the continued use of passwords as a sole factor. Once considered best practices, password rotation and complexity requirements are viewed as encouraging users to use, and reuse, weak passwords. Organizations are recommended to stop these practices per NIST 800-63 and use multi-factor authentication.
 

--- a/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication.md
+++ b/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication.md
@@ -27,7 +27,7 @@ Attackers can detect broken authentication using manual means and exploit them u
 
 Confirmation of the user's identity, authentication, and session management are critical to protect against authentication-related attacks. There may be authentication weaknesses if the application:
 
-* Permits automated attacks such as [credential stuffing](/www-community/attacks/Credental_stuffing), where the attacker has a list of valid usernames and passwords.
+* Permits automated attacks such as [credential stuffing](/www-community/attacks/Credential_stuffing), where the attacker has a list of valid usernames and passwords.
 * Permits brute force or other automated attacks.
 * Permits default, weak, or well-known passwords, such as "Password1" or "admin/admin“.
 * Uses weak or ineffective credential recovery and forgot-password processes, such as "knowledge-based answers", which cannot be made safe.


### PR DESCRIPTION
The Credential Stuffing link was giving a 404 error due to a misspelling.