### PR TITLE
Use displaytext for friendly tab naming/display

### DIFF
--- a/info.md
+++ b/info.md
@@ -7,7 +7,7 @@
 
 ### Downloads or Social Links
 * [Download](/www-pdf-archive/OWASP_Top_10-2017_%28en%29.pdf.pdf){:target='_blank' rel='noopener'}
-* [Other languages &rarr; tab 'translation_efforts']({{site.baseurl}}/#div-translation_efforts)
+* [Other languages &rarr; tab 'Translation Efforts']({{site.baseurl}}/#div-translation_efforts)
 * [Twitter](https://twitter.com/owasptop10)
 
 ### Code Repository

--- a/tab_data_2020.md
+++ b/tab_data_2020.md
@@ -1,5 +1,6 @@
 ---
 title: Data_2020
+displaytext: Data 2020
 layout:  col-sidebar
 tab: true
 order: 4

--- a/tab_translation_efforts.md
+++ b/tab_translation_efforts.md
@@ -1,5 +1,6 @@
 ---
 title: Translation_Efforts
+displaytext: Translation Efforts
 layout: col-sidebar
 tab: true
 order: 2


### PR DESCRIPTION
Add displaytext field to front mater. Instead of showing underscores. Per: https://owasp.org/migration/