### PR TITLE
Fix typo in broken authentication

### DIFF
--- a/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication.md
+++ b/OWASP_Top_Ten_2017/Top_10-2017_A2-Broken_Authentication.md
@@ -33,7 +33,7 @@ Confirmation of the user's identity, authentication, and session management are 
 * Permits brute force or other automated attacks.<br>
 * Permits default, weak, or well-known passwords, such as "Password1" or "admin/admin“.<br>
 * Uses weak or ineffective credential recovery and forgot-password processes, such as "knowledge-based answers", which cannot be made safe.<br>
-* Uses plain text, encrypted, or weakly hashed passwords (see [A3:2017-Sensitive Data Exposure](Top_10-2017_A3-Sensitive_Data_Exposure)).<br>
+* Uses plain text, unencrypted, or weakly hashed passwords (see [A3:2017-Sensitive Data Exposure](Top_10-2017_A3-Sensitive_Data_Exposure)).<br>
 * Has missing or ineffective multi-factor authentication.<br>
 * Exposes Session IDs in the URL (e.g., URL rewriting).<br>
 * Does not rotate Session IDs after successful login.<br>


### PR DESCRIPTION
Noticed a pretty confusing typo when reading the 2017 spec for Broken Authentication, assuming I haven't dramatically misunderstood its intention!

Also have PRs for the same issue in [Top10](https://github.com/OWASP/Top10/pull/507) and [RiskAssessmentFramework](https://github.com/OWASP/RiskAssessmentFramework/pull/60).