### PR TITLE
updated link for OWASP Top 10 2017

### DIFF
--- a/info.md
+++ b/info.md
@@ -11,7 +11,10 @@
 
 ### Downloads or Social Links
 
-- &bull; [OWASP Top 10 2017](/www-pdf-archive/OWASP_Top_10-2017_%28en%29.pdf.pdf){:target='_blank' rel='noopener'}
+- <a href="https://owasp.org/www-pdf-archive/OWASP_Top_10-2017_%28en%29.pdf.pdf" target="_blank" rel="noopener">
+  OWASP Top 10 2017
+</a>
+
 - &bull; [Other languages &rarr; tab 'Translation Efforts']({{site.baseurl}}/#div-translation_efforts)
 
 ### Social


### PR DESCRIPTION
Added Direct download link for OWASP Top 10 2017 which was not working earlier.

![1](https://user-images.githubusercontent.com/86834649/236393132-6319382b-abb7-4538-b7d4-52af421d978a.png)
