### PR TITLE
docs: fix broken reference on A10:2017 Logging & Monitoring page

### DIFF
--- a/2017/A10_2017-Insufficient_Logging%26Monitoring.md
+++ b/2017/A10_2017-Insufficient_Logging%26Monitoring.md
@@ -30,7 +30,7 @@ This issue is included in the Top 10 based on an [industry survey](https://owasp
 One strategy for determining if you have sufficient monitoring is to examine the logs following penetration testing. The testers' actions should be recorded sufficiently to understand what damages they may have inflicted.
 {%- include risk_description.html pos="right" -%}
 Most successful attacks start with vulnerability probing. Allowing such probes to continue can raise the likelihood of successful exploit to nearly 100%.<br>
-In 2016, identifying a breach took an average of 191 days – plenty of time for damage to be inflicted.
+In 2016, identifying a breach took an average of 191 days – plenty of time for damage to be inflicted, according to the [IBM/Ponemon 2017 Cost of a Data Breach Study](https://documents.ncsl.org/wwwncsl/Task-Forces/Cybersecurity-Privacy/IBM_Ponemon2017CostofDataBreachStudy.pdf).
 {%- include risk_end.html -%}
 
 {%- include t10_subsection_begin.html -%}

--- a/2017/A10_2017-Insufficient_Logging%26Monitoring.md
+++ b/2017/A10_2017-Insufficient_Logging%26Monitoring.md
@@ -30,7 +30,7 @@ This issue is included in the Top 10 based on an [industry survey](https://owasp
 One strategy for determining if you have sufficient monitoring is to examine the logs following penetration testing. The testers' actions should be recorded sufficiently to understand what damages they may have inflicted.
 {%- include risk_description.html pos="right" -%}
 Most successful attacks start with vulnerability probing. Allowing such probes to continue can raise the likelihood of successful exploit to nearly 100%.<br>
-In 2016, identifying a breach took an average of 191 days – plenty of time for damage to be inflicted, according to the [IBM/Ponemon 2017 Cost of a Data Breach Study](https://documents.ncsl.org/wwwncsl/Task-Forces/Cybersecurity-Privacy/IBM_Ponemon2017CostofDataBreachStudy.pdf).
+In 2016, identifying a breach took an [average of 191 days](https://documents.ncsl.org/wwwncsl/Task-Forces/Cybersecurity-Privacy/IBM_Ponemon2017CostofDataBreachStudy.pdf) – plenty of time for damage to be inflicted.
 {%- include risk_end.html -%}
 
 {%- include t10_subsection_begin.html -%}

--- a/2017/A10_2017-Insufficient_Logging%26Monitoring.md
+++ b/2017/A10_2017-Insufficient_Logging%26Monitoring.md
@@ -30,7 +30,7 @@ This issue is included in the Top 10 based on an [industry survey](https://owasp
 One strategy for determining if you have sufficient monitoring is to examine the logs following penetration testing. The testers' actions should be recorded sufficiently to understand what damages they may have inflicted.
 {%- include risk_description.html pos="right" -%}
 Most successful attacks start with vulnerability probing. Allowing such probes to continue can raise the likelihood of successful exploit to nearly 100%.<br>
-In 2016, identifying a breach took an [average of 191 days](https://www-01.ibm.com/common/ssi/cgi-bin/ssialias?htmlfid=SEL03130WWEN&) – plenty of time for damage to be inflicted.
+In 2016, identifying a breach took an average of 191 days – plenty of time for damage to be inflicted.
 {%- include risk_end.html -%}
 
 {%- include t10_subsection_begin.html -%}


### PR DESCRIPTION
This removes a dead external IBM reference from the
A10:2017 Insufficient Logging & Monitoring page, as noted in issue #38.
Existing redirect mappings for encoded URLs were reviewed and left
unchanged.